### PR TITLE
Replace react-tilt with react-parallax-tilt

### DIFF
--- a/components/experiment.tsx
+++ b/components/experiment.tsx
@@ -26,7 +26,7 @@ const ExperimentItem = ({ experiment }: Props) => {
   }
 
   return (
-    <Tilter options={{ scale: 1, speed: 200 }}>
+    <Tilter scale={1} transitionSpeed={200}>
       <StyledExperimentItemContainer
         className="experiments-container"
         href={experiment.link}

--- a/components/styles/experiments.styles.ts
+++ b/components/styles/experiments.styles.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import Tilt from 'react-tilt';
+import Tilt from 'react-parallax-tilt';
 
 export const Tilter = styled(Tilt)`
   padding: 40px 0;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-feather": "2.0.10",
-    "react-tilt": "0.1.4",
+    "react-parallax-tilt": "^1.7.137",
     "remark": "14.0.2",
     "remark-highlight.js": "7.0.1",
     "sharp": "0.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,9 +25,9 @@ dependencies:
   react-feather:
     specifier: 2.0.10
     version: 2.0.10(react@18.2.0)
-  react-tilt:
-    specifier: 0.1.4
-    version: 0.1.4(react-dom@18.2.0)(react@18.2.0)
+  react-parallax-tilt:
+    specifier: ^1.7.137
+    version: 1.7.137(react-dom@18.2.0)(react@18.2.0)
   remark:
     specifier: 14.0.2
     version: 14.0.2
@@ -5543,11 +5543,11 @@ packages:
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  /react-tilt@0.1.4(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-bVeRumg+RIn6QN8S92UmubGqX/BG6/QeQISBeAcrS/70dpo/jVj+sjikIawDl5wTuPdubFH8zH0EMulWIctsnw==}
+  /react-parallax-tilt@1.7.137(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-PsuOXpsa/55n23/sd7sbSd91Fm7z37o1WYV2V0GMyo1IguaXmdoVGIqAZFynaxNWS6Go9TKR+CrzYuQHIiE6/g==}
     peerDependencies:
-      react: ^15.0.0 || ^16.0.0-beta || ^16.0.0
-      react-dom: ^15.0.0 || ^16.0.0-beta || ^16.0.0
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)


### PR DESCRIPTION
## Description

We have encountered some issues with react-tilt after the update to version 1.0.2, particularly when used with Next.js and the pages/ directory. We have addressed this issue by switching to react-parallax-tilt. For more information on the issue with react-tilt, here is the https://github.com/jonathandion/react-tilt/issues/26 in the react-tilt repository.

## Testing

- [x] Deploy the updated project to Netlify. https://eloquent-hamster-566c38.netlify.app/