### PR TITLE
Temporarily work around Netlify, ESM, next/image

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && sed -i 's/\"type\": \"module\"/\"type\": \"commonjs\"/' package.json",
     "start": "next start",
     "build:rss": "tsx ./utils/rss.ts",
     "lint": "next lint"


### PR DESCRIPTION
Netlify currently has a problem with ESM and next/image:

Temporarily work around this problem in a hacky way by changing `type:module` to `type:commonjs`.

```
[ReferenceError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError) - module is not defined in ES module scope This file is being treated as an ES module because it has a '.js' file extension and '/var/task/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.

ReferenceError: module is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension and '/var/task/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
    at file:///var/task/_ipx.js:1:1
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25)
```

<img width="852" alt="Screenshot 2024-01-07 at 20 38 07" src="https://github.com/vickonrails/next-starter-peacock/assets/80746311/3d3a92c8-fb35-4e46-a154-dec945a93af9">
