### PR TITLE
Remove build workaround for Netlify Next.js v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build && sed -i 's/\"type\": \"module\"/\"type\": \"commonjs\"/' package.json",
+    "build": "next build",
     "start": "next start",
     "build:rss": "tsx ./utils/rss.ts",
     "lint": "next lint"


### PR DESCRIPTION
Closes #164 

With Netlify's update to the [Next.js Runtime v5](https://docs.netlify.com/frameworks/next-js/overview/#prerequisites), improvements have been introduced, including support for ESM and `Next/Image`. As a result, the workaround we previously created, using the `sed` command to modify `type:module` to `type:commonJs` during the `build` process, is no longer necessary.

## Test

- [x] Removed the `build` command workaround and re-deployed on Netlify, the latest `@netlify/plugin-nextjs@5.0.0-rc.4` was added, and the images are visible using `Next/Image`.
```
1:58:59 PM: ❯ Installing plugins
1:58:59 PM:    - @netlify/plugin-nextjs@5.0.0-rc.4
```

<img width="2764" alt="Screenshot 2024-03-13 at 14 45 53" src="https://github.com/upleveled/next-starter-peacock/assets/80746311/ea1fbf42-4f5b-43e1-92f5-27c976c70240">
